### PR TITLE
Add missing `__alias__` property

### DIFF
--- a/meltano_map_transform/mapper.py
+++ b/meltano_map_transform/mapper.py
@@ -25,6 +25,7 @@ class StreamTransform(InlineMapper):
                         "properties": {
                             "__filter__": {"type": ["string", "null"]},
                             "__source__": {"type": ["string", "null"]},
+                            "__alias__": {"type": ["string", "null"]},
                             "__else__": {"type": ["null"]},
                             "__key_properties__": {
                                 "type": ["array", "null"],


### PR DESCRIPTION
The code seems to work nonetheless since `__alias__` is defined in `singer-sdk`:

https://gitlab.com/meltano/sdk/-/blob/ca890549/singer_sdk/mapper.py#L35

However, better to have it here I guess :)