### PR TITLE
Adjust reference to poetry-core

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -53,7 +53,7 @@ module = [
 ]
 
 [build-system]
-requires = ["poetry-core @ git+https://github.com/python-poetry/poetry-core.git@master"]
+requires = ["poetry_core>=1.0.0"]
 build-backend = "poetry.core.masonry.api"
 
 [tool.poetry.scripts]


### PR DESCRIPTION
It doesn't look like it's necessary to reference the specific branch anymore, and now that poetry-core changed from master to main this is causing the branch to not be found

Closes #19