### PR TITLE
chore: bump to sdk v0.14.0

### DIFF
--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -1,0 +1,32 @@
+{
+	"name": "Singer Dev Connector Image",
+	"image": "mcr.microsoft.com/devcontainers/python:3.10",
+	"features": {
+		"ghcr.io/devcontainers/features/node:1": {
+			"version": "none"
+		},
+		"ghcr.io/devcontainers/features/docker-in-docker:1": {},
+		"ghcr.io/devcontainers/features/github-cli:1": {},
+		"ghcr.io/devcontainers-contrib/features/bandit:1": {},
+		"ghcr.io/devcontainers-contrib/features/black:1": {},
+		"ghcr.io/devcontainers-contrib/features/coverage-py:1": {},
+		"ghcr.io/devcontainers-contrib/features/isort:1": {},
+		"ghcr.io/devcontainers-contrib/features/meltano:1": {},
+		"ghcr.io/devcontainers-contrib/features/mypy:1": {},
+		"ghcr.io/devcontainers-contrib/features/poetry:1": {},
+		"ghcr.io/devcontainers-contrib/features/pre-commit:1": {},
+		"ghcr.io/devcontainers-contrib/features/pylint:1": {}
+	},
+
+	// Use 'postCreateCommand' to run commands after the container is created.
+	"postCreateCommand": "poetry install"
+
+	// Use 'forwardPorts' to make a list of ports inside the container available locally.
+	// "forwardPorts": [],
+
+	// Configure tool-specific properties.
+	// "customizations": {},
+
+	// Uncomment to connect as root instead. More info: https://aka.ms/dev-containers-non-root.
+	// "remoteUser": "root"
+}

--- a/poetry.lock
+++ b/poetry.lock
@@ -631,7 +631,7 @@ python-versions = ">=2.5, !=3.0.*, !=3.1.*, !=3.2.*"
 
 [[package]]
 name = "singer-sdk"
-version = "0.13.1"
+version = "0.14.0"
 description = "A framework for building Singer taps"
 category = "main"
 optional = false
@@ -660,7 +660,7 @@ sqlalchemy = ">=1.4,<2.0"
 typing-extensions = ">=4.2.0,<5.0.0"
 
 [package.extras]
-docs = ["myst-parser (>=0.17.2,<0.19.0)", "sphinx (>=4.5,<6.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)", "sphinx-rtd-theme (>=0.5.2,<1.1.0)"]
+docs = ["myst-parser (>=0.17.2,<0.19.0)", "sphinx (>=4.5,<6.0)", "sphinx-autobuild (>=2021.3.14,<2022.0.0)", "sphinx-copybutton (>=0.3.1,<0.6.0)", "sphinx-rtd-theme (>=0.5.2,<1.2.0)"]
 
 [[package]]
 name = "six"
@@ -771,7 +771,7 @@ testing = ["func-timeout", "jaraco.itertools", "pytest (>=6)", "pytest-black (>=
 [metadata]
 lock-version = "1.1"
 python-versions = "<3.11,>=3.7.1"
-content-hash = "9b00bbd1c9e32a7a72c7ab3c230fdd62cf473c15514b3ccbc78d8c531b9c40f0"
+content-hash = "ed4866cb34d83f45624f7f56dc5676efbaa059407beefae03ded34dbb6587c99"
 
 [metadata.files]
 appdirs = [
@@ -1315,8 +1315,8 @@ simplejson = [
     {file = "simplejson-3.17.6.tar.gz", hash = "sha256:cf98038d2abf63a1ada5730e91e84c642ba6c225b0198c3684151b1f80c5f8a6"},
 ]
 singer-sdk = [
-    {file = "singer_sdk-0.13.1-py3-none-any.whl", hash = "sha256:13c651affc15c82743dfb6b7eddfc2bb487d2bd786ec98b3349174444fc2856d"},
-    {file = "singer_sdk-0.13.1.tar.gz", hash = "sha256:b9636843c78de3954e064ec52cb8269950a0c099bdd4c4b96011e16e28f4ca2e"},
+    {file = "singer_sdk-0.14.0-py3-none-any.whl", hash = "sha256:634802ed4e9c71e9ade4bb772f4b2f1510b2cb971957f96a163fb592560a5cd8"},
+    {file = "singer_sdk-0.14.0.tar.gz", hash = "sha256:c69b670f5202e833db3c5ecac68dabb280f6cdaa645a55c2a5dce256554eddb0"},
 ]
 six = [
     {file = "six-1.16.0-py2.py3-none-any.whl", hash = "sha256:8abb2f1d86890a2dfb989f9a77cfcfd3e47c2a354b01111771326f8aa26e0254"},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,7 +18,7 @@ documentation = "https://github.com/MeltanoLabs/meltano-map-transform#readme"
 
 [tool.poetry.dependencies]
 python = "<3.11,>=3.7.1"
-singer-sdk = "0.13.1"
+singer-sdk = "0.14.0"
 
 [tool.poetry.dev-dependencies]
 black = {version = "^22.10", allow-prereleases = true}


### PR DESCRIPTION
This brings the `datetime` library from v0.14.0 - and other updates here: https://github.com/meltano/sdk/releases/tag/v0.14.0

Note:

This also builds on:

- #78

That one should probably merge first. If we are in a rush to merge, we can approve all at once or else rebase on main with the changes from #78.