### PR TITLE
test: Use env vars to alias a stream

### DIFF
--- a/meltano.yml
+++ b/meltano.yml
@@ -45,7 +45,10 @@ plugins:
     settings:
     - name: stream_maps
       kind: object
+    - name: stream_maps.customers.__alias__
+      kind: string
     mappings:
+    - name: uses_env_vars
     - name: hash_email
       config:
         stream_maps:


### PR DESCRIPTION
A little hacky, but does the trick:

```shell
MELTANO_MAP_TRANSFORMER_STREAM_MAPS_CUSTOMERS___ALIAS__=new_name meltano run tap-csv uses_env_vars target-sqlite
```

```console
$ sqlite3 -markdown output/tap_csv.db 'select * from new_name limit 3'
|        email         | first_name | id |   ip_address   | last_name |        __loaded_at         |
|----------------------|------------|----|----------------|-----------|----------------------------|
| ebook0@twitter.com   | Ethe       | 1  | 67.61.243.220  | Book      | 2024-09-12 20:09:53.130891 |
| mtire1@vkontakte.ru  | Myranda    | 2  | 151.194.73.229 | Tire      | 2024-09-12 20:09:53.130924 |
| rdorian2@twitpic.com | Remus      | 3  | 204.220.73.121 | Dorian    | 2024-09-12 20:09:53.130949 |
```

In response to https://meltano.slack.com/archives/C06A1MD6A6L/p1726054308298569.